### PR TITLE
Connect booking lookup form to API

### DIFF
--- a/components/BookingCard.tsx
+++ b/components/BookingCard.tsx
@@ -1,16 +1,40 @@
-export default function BookingCard({ booking }) {
+export type Booking = {
+  id: number;
+  name: string;
+  email: string;
+  tour: string;
+  date: string;
+  status: string;
+};
+
+type BookingCardProps = {
+  booking: Booking;
+};
+
+export default function BookingCard({ booking }: BookingCardProps) {
+  const travelDate = new Date(booking.date);
+
   return (
-    <div style={{
-      margin: "1rem 0",
-      padding: "1rem",
-      border: "1px solid #ddd",
-      borderRadius: "8px"
-    }}>
-      <h3>{booking.tourName}</h3>
-      <p><b>Date:</b> {new Date(booking.date).toLocaleDateString()}</p>
-      <p><b>Pickup:</b> {booking.pickup}</p>
-      <p><b>Status:</b> {booking.status}</p>
-      <p><b>Ref:</b> {booking.reference}</p>
+    <div className="mt-6 rounded-xl border border-purple-200 bg-purple-50 p-6 text-left shadow-sm">
+      <h3 className="text-2xl font-semibold text-purple-900">{booking.tour}</h3>
+      <dl className="mt-4 space-y-2 text-sm text-purple-900">
+        <div className="flex justify-between">
+          <dt className="font-medium">Guest</dt>
+          <dd>{booking.name}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="font-medium">Email</dt>
+          <dd>{booking.email}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="font-medium">Travel date</dt>
+          <dd>{travelDate.toLocaleDateString()}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="font-medium">Status</dt>
+          <dd className="font-semibold uppercase tracking-wide">{booking.status}</dd>
+        </div>
+      </dl>
     </div>
   );
 }

--- a/pages/api/lookup.ts
+++ b/pages/api/lookup.ts
@@ -8,7 +8,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { name, email } = req.body;
+  const { name, email } = req.body as { name?: string; email?: string };
+
+  if (!name || !email) {
+    return res.status(400).json({ message: "Name and email are required" });
+  }
 
   try {
     const booking = await prisma.bookings.findFirst({
@@ -19,7 +23,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(404).json({ message: "Booking not found" });
     }
 
-    res.status(200).json(booking);
+    res.status(200).json({
+      ...booking,
+      date: booking.date.toISOString(),
+    });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "Internal Server Error" });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,43 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
+import BookingCard, { Booking } from "../components/BookingCard";
 
 export default function Home() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("Finding booking for:", name, email);
-    // Later: call your API here
+    setError(null);
+    setBooking(null);
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/lookup", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name, email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const message = typeof data?.message === "string" ? data.message : "Booking not found";
+        setError(message);
+        return;
+      }
+
+      setBooking(data as Booking);
+    } catch (err) {
+      console.error("Failed to look up booking", err);
+      setError("Something went wrong. Please try again later.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -23,6 +53,7 @@ export default function Home() {
             placeholder="Enter your name"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            required
             className="px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
 
@@ -31,16 +62,26 @@ export default function Home() {
             placeholder="Enter your email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            required
             className="px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
 
           <button
             type="submit"
-            className="flex items-center justify-center bg-gradient-to-r from-purple-600 to-purple-800 hover:from-purple-700 hover:to-purple-900 text-white font-semibold py-3 rounded-lg transition duration-300 shadow-md"
+            disabled={isLoading || !name || !email}
+            className="flex items-center justify-center bg-gradient-to-r from-purple-600 to-purple-800 hover:from-purple-700 hover:to-purple-900 text-white font-semibold py-3 rounded-lg transition duration-300 shadow-md disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Find My Booking <span className="ml-2">🌙</span>
+            {isLoading ? "Searching..." : "Find My Booking"} <span className="ml-2">🌙</span>
           </button>
         </form>
+
+        {error && (
+          <p className="mt-6 rounded-lg bg-red-100 p-4 text-sm font-medium text-red-700" role="alert">
+            {error}
+          </p>
+        )}
+
+        {booking && <BookingCard booking={booking} />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- wire the booking lookup form to call the lookup API and surface loading/errors/results
- replace the booking card with a typed component that presents the real booking fields
- add API validation for missing parameters and normalise the booking date payload

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de109e57e48321b1edddd9b04c58a6